### PR TITLE
Update types.rs

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -198,13 +198,13 @@ pub struct SatelliteObject {
     pub prn: u16,
     #[serde(rename = "az")]
     /// Azimuth, degrees from true north.
-    pub azimuth: u32,
+    pub azimuth: f32,
     #[serde(rename = "el")]
     /// Elevation in degrees.
-    pub elevation: u32,
+    pub elevation: f32,
     #[serde(rename = "ss")]
     /// Signal strength in dB.
-    pub signal_strength: u32,
+    pub signal_strength: f32,
     /// Used in current solution? (SBAS/WAAS/EGNOS satellites may be flagged
     /// used if the solution has corrections from them, but not all drivers make
     /// this information available.)


### PR DESCRIPTION
The output of GPSD has changed.
ubuntu 18.04 gpsd 3.17
{"class":"SKY" ... "satellites":[
{"PRN":15,"el":73,"az":226,"ss":39,"used":true,"gnssid":0,"svid":15},

ubuntu 22.04 gpsd 3.22
{"class":"SKY" ... "satellites":[
{"PRN":15,"el":73.0,"az":226.0,"ss":39.0,"used":true,"gnssid":0,"svid":15}, 
unbounded_gpsd :132  DEBUG serde output: Err(Error("invalid type: floating point `73`, expected u32", line: 0, column: 0)) 
